### PR TITLE
Sync with PALEOboxes v0.19, PALEOmodel v0.15 setup changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOcopse"
 uuid = "4a6ed817-0e58-48c6-8452-9e9afc8cb508"
 authors = ["sd336 "]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -19,8 +19,8 @@ Documenter = "0.27"
 Infiltrator = "1.0"
 Interpolations = "0.13"
 MAT = "0.10"
-PALEOboxes = "0.18.4"
-PALEOmodel = "0.14"
+PALEOboxes = "0.19.1"
+PALEOmodel = "0.15"
 Plots = "1.0"
 Roots = "1.0, 2.0"
 TestEnv = "1.0"

--- a/src/PALEOcopse.jl
+++ b/src/PALEOcopse.jl
@@ -14,4 +14,25 @@ include("oceanfloor/Oceanfloor.jl")
 include("sedcrust/SedCrust.jl")
 include("biogeochem/BioGeoChem.jl")
 
+
+# Negligible difference Julia 1.7.3
+# function precompile_reactions()
+#     rdict = PB.find_all_reactions()
+    
+#     reactionlist = ["ReactionSrSed", "ReactionLandWeatheringFluxes", "ReactionSrLand", "ReactionLandArea", "ReactionForce_LIPs",
+#         "ReactionForce_CK_Solar", "ReactionLandWeatheringRates", "ReactionModelBergman2004", 
+#         "ReactionCIsotopes", "ReactionOceanCOPSE", "ReactionAtmOcean_A", "ReactionSedCrustCOPSE", "ReactionGlobalTemperatureBerner",
+#         "ReactionSrOceanfloor", "ReactionForce_CPlandrelbergman2004", "ReactionForce_UDWEbergman2004", "ReactionSeafloorWeathering",
+#         "ReactionSrMantleCrust", "ReactionLandBergman2004", "ReactionAtmOcean_O", "ReactionForce_spreadsheet", 
+#         "ReactionGlobalTemperatureCK1992", "ReactionLandBiota", "ReactionForce_Bbergman2004",
+#     ]
+#     for r in reactionlist
+#         PB.precompile_reaction(rdict, r)
+#     end
+
+#     return nothing
+# end
+
+# precompile_reactions()
+
 end

--- a/src/oceanfloor/Weathering.jl
+++ b/src/oceanfloor/Weathering.jl
@@ -60,7 +60,7 @@ end
 function PB.register_methods!(rj::ReactionSeafloorWeathering)
 
     CIsotopeType = rj.pars.CIsotope.v
-
+    PB.setfrozen!(rj.pars.CIsotope)
     vars = [
         PB.VarDep("global.RHOSFW",          "", "seafloor weathering-specific additional forcing (usually 1.0)"),
         PB.VarDep("(global.TEMP)",          "K", "global mean temperature"),
@@ -208,10 +208,12 @@ function set_distributionfromdepths(
     m::PB.ReactionMethod, 
     (vars, ), 
     cellrange::PB.AbstractCellRange, 
-    attribute_value
+    attribute_name
 )
     rj = m.reaction
-    attribute_value == :initial_value || return nothing
+    attribute_name == :setup || return nothing
+
+    @info "$(fullname(m)) ReactionSeafloorWeathering:"
 
     PB.get_length(rj.domain) == length(cellrange.indices) || 
         error("ReactionSeafloorWeathering $(PB.fullname(rj)) set_distributionfromdepths cellrange does not cover whole Domain")
@@ -230,8 +232,7 @@ function set_distributionfromdepths(
     
     normsum = sum(sfw_distribution)
     Atot = sum(vars.Afloor)
-    @info "ReactionSeafloorWeathering $(PB.fullname(rj)) "*
-        "sfw distributed among $nsfw of $(length(sfw_distribution)) boxes, area $normsum m^2 of $Atot m^2"
+    @info "    sfw distributed among $nsfw of $(length(sfw_distribution)) boxes, area $normsum m^2 of $Atot m^2"
     PB.setvalue!(rj.pars.sfw_distribution, sfw_distribution./normsum)
 
     return nothing

--- a/test/forcings/PlotForcings.ipynb
+++ b/test/forcings/PlotForcings.ipynb
@@ -98,7 +98,7 @@
     "# Initialize model Reactions (will read forcing data from files etc)\n",
     "PB.initialize_reactiondata!(model, modeldata)\n",
     "\n",
-    "PB.dispatch_setup(model, :initial_value, modeldata)\n",
+    "PB.dispatch_setup(model, :setup, modeldata)\n",
     "\n",
     "dispatchlists = modeldata.dispatchlists_all\n"
    ]

--- a/test/forcings/runforcingtests.jl
+++ b/test/forcings/runforcingtests.jl
@@ -34,7 +34,7 @@ import PALEOcopse
     PB.initialize_reactiondata!(model, modeldata)    
       
     @info "dispatch_setup"
-    PB.dispatch_setup(model, :initial_value, modeldata)
+    PB.dispatch_setup(model, :setup, modeldata)
    
     dispatchlists = modeldata.dispatchlists_all
  

--- a/test/global/runtemperaturetests.jl
+++ b/test/global/runtemperaturetests.jl
@@ -33,6 +33,8 @@ import PALEOcopse
  
     # check Reaction configuration
     PB.check_configuration(model)
+    # Initialise Reactions and non-state variables
+    PB.dispatch_setup(model, :setup, modeldata)
     # Initialise state variables to norm_value
     PB.dispatch_setup(model, :norm_value, modeldata)
     PB.copy_norm!(modeldata.solver_view_all)


### PR DESCRIPTION
There is now a new call to
    PB.dispatch_setup(model, :setup, modeldata)
with attribute_name=:setup, hence corresponding callback to setup methods.

This commit updates COPSE Reactions to do non-state-variable related initialisation
in setup callbacks when attribute_name=:setup (replaces previous
(ab)use of :initial_value for this).