### PR TITLE
Update for Parameter simplifications (PALEOboxes v0.20.4), model vs run

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOcopse"
 uuid = "4a6ed817-0e58-48c6-8452-9e9afc8cb508"
 authors = ["sd336 "]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -19,8 +19,8 @@ Documenter = "0.27"
 Infiltrator = "1.0"
 Interpolations = "0.13, 0.14"
 MAT = "0.10"
-PALEOboxes = "0.19.1, 0.20.0"
-PALEOmodel = "0.15.1"
+PALEOboxes = "0.20.4"
+PALEOmodel = "0.15.8"
 Plots = "1.0"
 Roots = "1.0, 2.0"
 TestEnv = "1.0"

--- a/examples/COPSE/COPSE_bergman2004_bergman2004.jl
+++ b/examples/COPSE/COPSE_bergman2004_bergman2004.jl
@@ -23,18 +23,20 @@ comparemodel = CompareOutput.copse_output_load("bergman2004","")
 
 use_TEMP_DAE = false
 
-run = copse_bergman2004_bergman2004_expts(
+model = copse_bergman2004_bergman2004_expts(
     ["baseline"],
     modelpars=Dict("temp_DAE"=>use_TEMP_DAE),
 )
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 # call ODE function to check derivative
 initial_deriv = similar(initial_state)
-PALEOmodel.ODE.ModelODE(modeldata)(initial_deriv, initial_state , (run=run, modeldata=modeldata), 0.0)
+PALEOmodel.SolverFunctions.ModelODE(modeldata)(initial_deriv, initial_state , nothing, 0.0)
 println("initial_state", initial_state)
 println("initial_deriv", initial_deriv)
+
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 if use_TEMP_DAE
     println("integrate, DAE")

--- a/examples/COPSE/COPSE_reloaded_bergman2004.jl
+++ b/examples/COPSE/COPSE_reloaded_bergman2004.jl
@@ -27,7 +27,7 @@ global_logger(ConsoleLogger(stderr,Logging.Info))
 # comparemodel = CompareOutput.copse_output_load("bergman2004","")
 # comparemodel = CompareOutput.copse_output_load("reloaded","original_baseline")
 comparemodel = nothing
-run = copse_reloaded_bergman2004_expts(
+model = copse_reloaded_bergman2004_expts(
     "bergman2004",
     ["baseline"],
 )
@@ -35,7 +35,7 @@ tspan=(-1000e6, 0)
 
 # No S cycle
 # comparemodel = CompareOutput.copse_output_load("reloaded","original_baseline")
-# run = copse_reloaded_bergman2004_expts(
+# model = copse_reloaded_bergman2004_expts(
 #     "bergman2004noS", 
 #     ["baseline"],
 #     comparemodel=comparemodel,
@@ -46,7 +46,7 @@ tspan=(-1000e6, 0)
 
 # Modern steady-state (constant forcings) with CO2 pulse
 # comparemodel=nothing
-# run = copse_reloaded_bergman2004_expts(
+# model = copse_reloaded_bergman2004_expts(
 #     "bergman2004", 
 #     [
 #         ("tforce_constant", 0.0),
@@ -62,15 +62,18 @@ tspan=(-1000e6, 0)
 # )
 # tspan=(-10e6, 10e6)
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 # call ODE function to check derivative
 initial_deriv = similar(initial_state)
-PALEOmodel.ODE.ModelODE(modeldata)(initial_deriv, initial_state , (run=run, modeldata=modeldata), 0.0)
+PALEOmodel.SolverFunctions.ModelODE(modeldata)(initial_deriv, initial_state , nothing, 0.0)
 println("initial_state", initial_state)
 println("initial_deriv", initial_deriv)
 
 println("integrate, no jacobian")
+                                          
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 # NB first run includes JIT time
 @time PALEOmodel.ODE.integrate(
     run, initial_state, modeldata, tspan,

--- a/examples/COPSE/COPSE_reloaded_reloaded.ipynb
+++ b/examples/COPSE/COPSE_reloaded_reloaded.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "include(\"copse_reloaded_reloaded_expts.jl\")\n",
     "\n",
-    "paleorun = copse_reloaded_reloaded_expts(\"reloaded\", [\"baseline\"])\n"
+    "model = copse_reloaded_reloaded_expts(\"reloaded\", [\"baseline\"])\n"
    ]
   },
   {
@@ -80,7 +80,7 @@
    },
    "outputs": [],
    "source": [
-    "initial_state, modeldata = PALEOmodel.initialize!(paleorun)"
+    "initial_state, modeldata = PALEOmodel.initialize!(model)"
    ]
   },
   {
@@ -99,10 +99,10 @@
     "# call ODE function to check derivative\n",
     "initial_deriv = similar(initial_state)\n",
     "\n",
-    "PALEOmodel.ODE.ModelODE(modeldata)(\n",
+    "PALEOmodel.SolverFunctions.ModelODE(modeldata)(\n",
     "    initial_deriv, \n",
     "    initial_state, \n",
-    "    (run=paleorun, modeldata=modeldata),\n",
+    "    nothing,\n",
     "    0.0\n",
     ")\n",
     "\n",
@@ -134,6 +134,9 @@
    "outputs": [],
    "source": [
     "println(\"integrate, ODE\")\n",
+    "\n",
+    "paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())\n",
+    "\n",
     "# first run includes JIT time\n",
     "@time PALEOmodel.ODE.integrate(\n",
     "    paleorun, initial_state, modeldata, (-1000e6, 0), \n",
@@ -206,7 +209,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "PB.show_parameters(paleorun.model)"
+    "PB.show_parameters(model)"
    ]
   },
   {
@@ -228,7 +231,7 @@
    "outputs": [],
    "source": [
     "ENV[\"COLUMNS\"]=600\n",
-    "PB.show_variables(paleorun.model, modeldata=modeldata, showlinks=true)"
+    "PB.show_variables(model, modeldata=modeldata, showlinks=true)"
    ]
   },
   {
@@ -273,8 +276,8 @@
    "source": [
     "# rerun and keep baseline output for comparison\n",
     "\n",
-    "PB.setvalue!(PB.get_reaction(paleorun.model, \"global\", \"temp_global\").pars.k_c, 4.328)\n",
-    "paleorun.output = PALEOmodel.OutputWriters.OutputMemory()\n",
+    "PB.setvalue!(PB.get_reaction(model, \"global\", \"temp_global\").pars.k_c, 4.328)\n",
+    "paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())\n",
     "PALEOmodel.ODE.integrate(\n",
     "    paleorun, initial_state, modeldata, (-1000e6, 0),\n",
     "    solvekwargs=(\n",
@@ -283,18 +286,15 @@
     ")\n",
     "output_baseline_3C = paleorun.output\n",
     "\n",
-    "PB.setvalue!(PB.get_reaction(paleorun.model, \"global\", \"temp_global\").pars.k_c, 8.656)\n",
-    "paleorun.output = PALEOmodel.OutputWriters.OutputMemory()\n",
+    "PB.setvalue!(PB.get_reaction(model, \"global\", \"temp_global\").pars.k_c, 8.656)\n",
+    "paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())\n",
     "PALEOmodel.ODE.integrate(\n",
     "    paleorun, initial_state, modeldata, (-1000e6, 0),\n",
     "    solvekwargs=(\n",
     "        reltol=1e-4,\n",
     "    )\n",
     ")\n",
-    "output_baseline_6C = paleorun.output\n",
-    "paleorun.output = PALEOmodel.OutputWriters.OutputMemory() # so another run doesn't overwrite output_baseline_6C\n",
-    "\n",
-    "\n"
+    "output_baseline_6C = paleorun.output\n"
    ]
   },
   {
@@ -342,7 +342,7 @@
    },
    "outputs": [],
    "source": [
-    "PB.show_methods_setup(paleorun.model)"
+    "PB.show_methods_setup(model)"
    ]
   },
   {
@@ -353,7 +353,7 @@
    },
    "outputs": [],
    "source": [
-    "PB.show_methods_initialize(paleorun.model)"
+    "PB.show_methods_initialize(model)"
    ]
   },
   {
@@ -364,7 +364,7 @@
    },
    "outputs": [],
    "source": [
-    "PB.show_methods_do(paleorun.model)"
+    "PB.show_methods_do(model)"
    ]
   },
   {
@@ -405,7 +405,7 @@
     "# Create a DataFrame of filtered VariableDomain objects\n",
     "# define a function to filter variables\n",
     "filterstatevars(attrb) = attrb[:vfunction] == PB.VF_StateExplicit\n",
-    "PB.show_variables(paleorun.model, modeldata=modeldata, filter=filterstatevars, showlinks=true)[:, [:name, :units, :vfunction, :description, :data, :dependencies]]\n"
+    "PB.show_variables(model, modeldata=modeldata, filter=filterstatevars, showlinks=true)[:, [:name, :units, :vfunction, :description, :data, :dependencies]]\n"
    ]
   },
   {

--- a/examples/COPSE/COPSE_reloaded_reloaded.jl
+++ b/examples/COPSE/COPSE_reloaded_reloaded.jl
@@ -26,7 +26,7 @@ global_logger(ConsoleLogger(stderr,Logging.Info))
 # Baseline Phanerozoic configuration
 # comparemodel = CompareOutput.copse_output_load("reloaded","reloaded_baseline")
 comparemodel = nothing
-run = copse_reloaded_reloaded_expts(
+model = copse_reloaded_reloaded_expts(
     "reloaded",
     ["baseline"],
 )
@@ -35,7 +35,7 @@ tspan=(-1000e6, 0)
 
 # OOE oscillations with VCI and linear mocb
 # comparemodel = CompareOutput.copse_output_load("reloaded","reloaded_baseline")
-# run = copse_reloaded_reloaded_expts(
+# model = copse_reloaded_reloaded_expts(
 #     "reloaded", 
 #     [
 #         "VCI",
@@ -49,15 +49,18 @@ tspan=(-1000e6, 0)
 # Integrate model
 ###########################################
 
-initial_state, modeldata = PALEOmodel.initialize!(run)
+initial_state, modeldata = PALEOmodel.initialize!(model)
 
 # call ODE function to check derivative
 initial_deriv = similar(initial_state)
-PALEOmodel.ODE.ModelODE(modeldata)(initial_deriv, initial_state , (run=run, modeldata=modeldata), 0.0)
+PALEOmodel.SolverFunctions.ModelODE(modeldata)(initial_deriv, initial_state , nothing, 0.0)
 println("initial_state", initial_state)
 println("initial_deriv", initial_deriv)
 
 println("integrate, no jacobian")
+
+run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+
 @time PALEOmodel.ODE.integrate(
     run, initial_state, modeldata, tspan, 
     solvekwargs=( # https://diffeq.sciml.ai/stable/basics/common_solver_opts/

--- a/examples/COPSE/copse_bergman2004_bergman2004_expts.jl
+++ b/examples/COPSE/copse_bergman2004_bergman2004_expts.jl
@@ -37,9 +37,7 @@ function copse_bergman2004_bergman2004_expts(
     copsemodel = PB.get_reaction(global_domain, "model_Bergman2004")
     PALEOcopse.COPSE.ModelBergman2004.set_parameters_modern_steady_state(copsemodel)
 
-    run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
-    return run
+    return model
 end
 
 

--- a/examples/COPSE/copse_reloaded_bergman2004_expts.jl
+++ b/examples/COPSE/copse_reloaded_bergman2004_expts.jl
@@ -92,23 +92,20 @@ function copse_reloaded_bergman2004_expts(
 
     # set parameters for steady-state
     rct_ocean   = PB.get_reaction(model, "ocean", "oceanburial_copse")
-    mtotpb      = rct_ocean.pars.k2_mocb.v/rct_ocean.pars.CPsea0.v  +rct_ocean.pars.k7_capb.v +rct_ocean.pars.k6_fepb.v
+    mtotpb      = rct_ocean.pars.k2_mocb[]/rct_ocean.pars.CPsea0[]  +rct_ocean.pars.k7_capb[] +rct_ocean.pars.k6_fepb[]
     rct_degass  = PB.get_reaction(model, "sedcrust", "sedcrust_copse")
     
     PALEOcopse.Land.LandCOPSEReloaded.set_steady_state(
         PB.get_reaction(model, "land", "land_fluxes"), 
-        rct_ocean.pars.k2_mocb.v,
+        rct_ocean.pars.k2_mocb[],
         mtotpb,
-        rct_degass.pars.k12_ccdeg.v,
-        rct_degass.pars.k13_ocdeg.v, 
+        rct_degass.pars.k12_ccdeg[],
+        rct_degass.pars.k13_ocdeg[], 
         0.0, 
         0.0
     )
 
-                                          
-    run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
-    return run
+    return model
 end
 
 function copse_reloaded_bergman2004_plot_summary(

--- a/examples/COPSE/copse_reloaded_reloaded_expts.jl
+++ b/examples/COPSE/copse_reloaded_reloaded_expts.jl
@@ -94,18 +94,18 @@ function copse_reloaded_reloaded_expts(
 
     # set parameters for carbonate-silicate weathering steady-state
     rct_ocean       = PB.get_reaction(model, "ocean", "oceanburial_copse")
-    mtotpb = rct_ocean.pars.k2_mocb.v/rct_ocean.pars.CPsea0.v  +rct_ocean.pars.k7_capb.v +rct_ocean.pars.k6_fepb.v
+    mtotpb = rct_ocean.pars.k2_mocb[]/rct_ocean.pars.CPsea0[]  +rct_ocean.pars.k7_capb[] +rct_ocean.pars.k6_fepb[]
     rct_degass      = PB.get_reaction(model, "sedcrust", "sedcrust_copse")
     rct_sfw         = PB.get_reaction(model, "oceanfloor", "sfw")
     rct_land_fluxes = PB.get_reaction(model, "land", "land_fluxes")
     PALEOcopse.Land.LandCOPSEReloaded.set_steady_state(
         rct_land_fluxes, 
-        rct_ocean.pars.k2_mocb.v,
+        rct_ocean.pars.k2_mocb[],
         mtotpb,
-        rct_degass.pars.k12_ccdeg.v,
-        rct_degass.pars.k13_ocdeg.v, 
+        rct_degass.pars.k12_ccdeg[],
+        rct_degass.pars.k13_ocdeg[], 
         0.0,
-        rct_sfw.pars.k_sfw.v
+        rct_sfw.pars.k_sfw[]
     )
 
     # set parameters for Sr steady state
@@ -114,15 +114,13 @@ function copse_reloaded_reloaded_expts(
     PALEOcopse.BioGeoChem.Strontium.set_Sr_fluxes_steady_state!(
         rct_Sr_land,
         rct_Sr_oceanfloor,
-        rct_land_fluxes.pars.k_basw.v,
-        rct_land_fluxes.pars.k_granw.v, 
-        rct_land_fluxes.pars.k14_carbw.v, 
-        rct_sfw.pars.k_sfw.v
+        rct_land_fluxes.pars.k_basw[],
+        rct_land_fluxes.pars.k_granw[], 
+        rct_land_fluxes.pars.k14_carbw[], 
+        rct_sfw.pars.k_sfw[]
     )
                                           
-    run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
-
-    return run
+    return model
 end
 
 function copse_reloaded_reloaded_plot_summary(

--- a/examples/COPSE/runtests.jl
+++ b/examples/COPSE/runtests.jl
@@ -27,8 +27,11 @@ skipped_testsets = [
     # load archived model output 
     comparemodel = CompareOutput.copse_output_load("reloaded", "reloaded_baseline")
 
-    run = copse_reloaded_reloaded_expts("reloaded", ["baseline"])
-    initial_state, modeldata = PALEOmodel.initialize!(run)
+    model = copse_reloaded_reloaded_expts("reloaded", ["baseline"])
+    initial_state, modeldata = PALEOmodel.initialize!(model)
+
+    run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
+
     @time PALEOmodel.ODE.integrate(
         run, initial_state, modeldata, (-1000e6, 0), 
         solvekwargs=(
@@ -83,9 +86,11 @@ end
 
     comparemodel = CompareOutput.copse_output_load("reloaded","original_baseline")
 
-    run = copse_reloaded_bergman2004_expts("bergman2004", ["baseline"])
+    model = copse_reloaded_bergman2004_expts("bergman2004", ["baseline"])
 
-    initial_state, modeldata = PALEOmodel.initialize!(run)
+    initial_state, modeldata = PALEOmodel.initialize!(model)
+
+    run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
 
     @time PALEOmodel.ODE.integrate(
         run, initial_state, modeldata, (-1000e6, 0), 
@@ -140,10 +145,12 @@ end
 
     comparemodel = CompareOutput.copse_output_load("bergman2004","")
 
-    run = copse_bergman2004_bergman2004_expts(["baseline"])
+    model = copse_bergman2004_bergman2004_expts(["baseline"])
 
-    initial_state, modeldata = PALEOmodel.initialize!(run)
+    initial_state, modeldata = PALEOmodel.initialize!(model)
 
+    run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
+    
     @time PALEOmodel.ODE.integrate(
         run, initial_state, modeldata, (-600e6, 0),
         solvekwargs=(

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -12,3 +12,7 @@ PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
+
+[compat]
+PALEOboxes = "0.20.4"
+PALEOmodel = "0.15.8"

--- a/src/Forcings/LipForcing.jl
+++ b/src/Forcings/LipForcing.jl
@@ -262,7 +262,7 @@ end
 
 function PB.register_methods!(rj::ReactionForce_LIPs)
      
-    CIsotopeType = rj.pars.CIsotope.v
+    CIsotopeType = rj.pars.CIsotope[]
     PB.setfrozen!(rj.pars.CIsotope)
     @info "register_methods! ReactionForce_LIPs: $(PB.fullname(rj)) CIsotopeType=$(CIsotopeType)"
 
@@ -291,25 +291,25 @@ function PB.register_methods!(rj::ReactionForce_LIPs)
     return nothing
 end
 
-function setup_force_LIPs(m::PB.ReactionMethod, (), cellrange::PB.AbstractCellRange, attribute_name)
+function setup_force_LIPs(m::PB.ReactionMethod, pars, (), cellrange::PB.AbstractCellRange, attribute_name)
     rj = m.reaction
 
     attribute_name == :setup || return nothing
 
-    lipfile = joinpath(rj.pars.datafolder.v, rj.pars.datafile.v)
+    lipfile = joinpath(pars.datafolder[], pars.datafile[])
     @info "setup_force_LIPs! ReactionForce_LIPs: $(PB.fullname(rj)) loading LIP forcing from 'datafolder/datafile'='$(lipfile)'"
 
     rj.LIP_data = read_lips_xlsx(lipfile)
 
-    lipkwargs = (smoothempl=rj.pars.smoothempl.v, )
+    lipkwargs = (smoothempl=pars.smoothempl[], )
 
-    rj.default_lambda = find_default_lambda(rj.pars.present_day_CFB_area.v, rj.LIP_data, lipkwargs )
+    rj.default_lambda = find_default_lambda(pars.present_day_CFB_area[], rj.LIP_data, lipkwargs )
 
     @info "    found default_lambda=$(rj.default_lambda) "*
-        "to match present_day_CFB_area = $(rj.pars.present_day_CFB_area.v) km^2"
+        "to match present_day_CFB_area = $(pars.present_day_CFB_area[]) km^2"
  
-    co2releasefield = Symbol(rj.pars.co2releasefield.v)
-    @info "    add LIP CO2 release from $(rj.pars.co2releasefield.v) field"
+    co2releasefield = Symbol(pars.co2releasefield[])
+    @info "    add LIP CO2 release from $(pars.co2releasefield[]) field"
 
     empty!(rj.LIPs)
     rj.LIPs = create_LIPs(rj.LIP_data, co2releasefield, rj.default_lambda; lipkwargs...)

--- a/src/landsurface/LandArea.jl
+++ b/src/landsurface/LandArea.jl
@@ -47,29 +47,29 @@ function PB.register_methods!(rj::ReactionLandArea)
         PB.VarPropScalar("BA_AREA",  "",  "Basalt area normalized to present day"),
     ]
 
-    if rj.pars.f_granitearea.v == "Fixed"
+    if rj.pars.f_granitearea[] == "Fixed"
         # no additional Variables needed
-    elseif rj.pars.f_granitearea.v == "Forced"
+    elseif rj.pars.f_granitearea[] == "Forced"
         push!(vars, PB.VarDepScalar("global.GRAN",     "",  "Granite area forcing normalized to present-day"))
-    elseif rj.pars.f_granitearea.v == "OrgEvapForced"
+    elseif rj.pars.f_granitearea[] == "OrgEvapForced"
         push!(vars, PB.VarDepScalar("global.GRAN",     "",  "Granite area forcing normalized to present-day"))
         push!(vars, PB.VarDepScalar("global.ORGEVAP_AREA", "",  "Contribution of silceous and shale_coal areas to overall non-basalt silicate weathering flux"))
     else
-        error("$(PB.fullname(rj)) configuration error invalid f_granitearea=$(rj.pars.f_granitearea.v)")
+        error("$(PB.fullname(rj)) configuration error invalid f_granitearea=$(rj.pars.f_granitearea[])")
     end
 
-    if rj.pars.f_basaltarea.v == "Fixed"
+    if rj.pars.f_basaltarea[] == "Fixed"
         # no additional Variables needed
-    elseif rj.pars.f_basaltarea.v == "Forced"
+    elseif rj.pars.f_basaltarea[] == "Forced"
         push!(vars, PB.VarDepScalar("global.BA",     "",  "Basalt area forcing normalized to present-day"))
-    elseif rj.pars.f_basaltarea.v == "g3_2014_construct_from_lips"
+    elseif rj.pars.f_basaltarea[] == "g3_2014_construct_from_lips"
         push!(vars,
             PB.VarDepScalar("global.CFB_area", "km^2",  "Continental flood basalt area"),
             PB.VarDepScalar("global.DEGASS",   "km^2",  "Normalized degass forcing"),
             PB.VarPropScalar("oib_area",  "km^2",  "Ocean island basalt area"),
         )
     else
-        error("$(PB.fullname(rj)) configuration error invalid f_basaltarea=$(rj.pars.f_basaltarea.v)")
+        error("$(PB.fullname(rj)) configuration error invalid f_basaltarea=$(rj.pars.f_basaltarea[])")
     end  
 
     PB.add_method_do!(rj, do_land_area, (PB.VarList_namedtuple(vars),) )
@@ -77,28 +77,28 @@ function PB.register_methods!(rj::ReactionLandArea)
     return nothing
 end
 
-function do_land_area(m::PB.ReactionMethod, (vars, ), cellrange::PB.AbstractCellRange, deltat)
+function do_land_area(m::PB.ReactionMethod, pars, (vars, ), cellrange::PB.AbstractCellRange, deltat)
     rj = m.reaction
 
-    if rj.pars.f_granitearea.v == "Fixed"
+    if pars.f_granitearea[] == "Fixed"
         vars.GRAN_AREA[] = 1.0
-    elseif rj.pars.f_granitearea.v == "Forced"
+    elseif pars.f_granitearea[] == "Forced"
         vars.GRAN_AREA[] = vars.GRAN[]
-    elseif rj.pars.f_granitearea.v == "OrgEvapForced"
-        vars.GRAN_AREA[] = (1.0-rj.pars.orgevapfrac.v)*vars.GRAN[] + rj.pars.orgevapfrac.v*vars.ORGEVAP_AREA[]
+    elseif pars.f_granitearea[] == "OrgEvapForced"
+        vars.GRAN_AREA[] = (1.0-pars.orgevapfrac[])*vars.GRAN[] + pars.orgevapfrac[]*vars.ORGEVAP_AREA[]
     else
-        error("$(PB.fullname(rj)) configuration error invalid f_granitearea=$(rj.pars.f_granitearea.v)")
+        error("$(PB.fullname(rj)) configuration error invalid f_granitearea=$(pars.f_granitearea[])")
     end
 
-    if rj.pars.f_basaltarea.v == "Fixed"
+    if pars.f_basaltarea[] == "Fixed"
         vars.BA_AREA[]  = 1.0
-    elseif rj.pars.f_basaltarea.v == "Forced"
+    elseif pars.f_basaltarea[] == "Forced"
         vars.BA_AREA[]  = vars.BA[]
-    elseif rj.pars.f_basaltarea.v == "g3_2014_construct_from_lips"
-        vars.oib_area[] = rj.pars.oib_area_scaling.v*vars.DEGASS[]
-        vars.BA_AREA[] = (vars.CFB_area[] + vars.oib_area[])/rj.pars.present_basalt_area.v
+    elseif pars.f_basaltarea[] == "g3_2014_construct_from_lips"
+        vars.oib_area[] = pars.oib_area_scaling[]*vars.DEGASS[]
+        vars.BA_AREA[] = (vars.CFB_area[] + vars.oib_area[])/pars.present_basalt_area[]
     else
-        error("$(PB.fullname(rj)) configuration error invalid f_basaltarea=$(rj.pars.f_basaltarea.v)")
+        error("$(PB.fullname(rj)) configuration error invalid f_basaltarea=$(pars.f_basaltarea[])")
     end  
 
     return nothing

--- a/src/landsurface/LandCOPSEReloaded.jl
+++ b/src/landsurface/LandCOPSEReloaded.jl
@@ -95,9 +95,8 @@ function PB.register_methods!(rj::ReactionLandBiota)
     return nothing
 end
 
-function do_land_biota(m::PB.ReactionMethod, (D, ),  cellrange::PB.AbstractCellRange, deltat)
+function do_land_biota(m::PB.ReactionMethod, pars, (D, ),  cellrange::PB.AbstractCellRange, deltat)
     # copse_landbiota_reloaded
-    pars = m.reaction.pars
 
     # effect of temp on VEG
     for i in cellrange.indices
@@ -116,47 +115,47 @@ function do_land_biota(m::PB.ReactionMethod, (D, ),  cellrange::PB.AbstractCellR
     D.V_o2[] = max(1.5 - 0.5*D.pO2PAL[], 0.0)
 
     # full VEG limitation
-    if pars.f_npp.v == "original"
+    if pars.f_npp[] == "original"
         D.V_co2[] = V_co2_orig()
         foreach(i -> D.V_npp[i] = 2*D.EVO[]*D.V_T[i]*D.V_o2[]*D.V_co2[], cellrange.indices)
-    elseif pars.f_npp.v == "noT"
+    elseif pars.f_npp[] == "noT"
         D.V_co2[] = V_co2_orig()
         foreach(i -> D.V_npp[i] = 2*D.EVO[]*0.84*D.V_o2[]*D.V_co2[], cellrange.indices)
-    elseif pars.f_npp.v == "noO2"
+    elseif pars.f_npp[] == "noO2"
         D.V_co2[] = V_co2_orig()
         D.V_o2[] = NaN
         foreach(i -> D.V_npp[i] = 2*D.EVO[]*D.V_T[i]*1.0*D.V_co2[], cellrange.indices)
-    elseif pars.f_npp.v == "noCO2"
+    elseif pars.f_npp[] == "noCO2"
         D.V_co2[] = NaN
         foreach(i -> D.V_npp[i] = 2*D.EVO[]*D.V_T[i]*D.V_o2[]*0.5952381, cellrange.indices)
-    elseif pars.f_npp.v == "bernerCO2"
+    elseif pars.f_npp[] == "bernerCO2"
         D.V_co2[] = 2*D.pCO2PAL[] / (1.0 + D.pCO2PAL[]) # Berner choice
         foreach(i -> D.V_npp[i] = D.EVO[]*(D.V_T[i]/0.84)*D.V_o2[]*D.V_co2[], cellrange.indices)
-    elseif pars.f_npp.v == "newCO2"
+    elseif pars.f_npp[] == "newCO2"
         D.V_co2[] = D.pCO2PAL[]^0.5
         foreach(i -> D.V_npp[i] = D.EVO[]*(D.V_T[i]/0.84)*D.V_o2[]*D.V_co2[], cellrange.indices)
-    elseif pars.f_npp.v == "constant"
+    elseif pars.f_npp[] == "constant"
         D.V_co2[] = NaN
         D.V_o2[] = NaN
         foreach(i -> D.V_npp[i] = D.EVO[], cellrange.indices)
     else
-        error("Unknown f_npp ", pars.f_npp.v)
+        error("Unknown f_npp ", pars.f_npp[])
     end
   
 
     # fire feedback
     # calculate atmospheric mixing ratio of O2 (for constant atmospheric N etc!)
     #(only used for fire ignition probability)
-    D.mrO2[] = D.pO2PAL[]  /   ( D.pO2PAL[]  +pars.k16_PANtoO.v )
-    if pars.f_ignit.v == "original"
+    D.mrO2[] = D.pO2PAL[]  /   ( D.pO2PAL[]  +pars.k16_PANtoO[] )
+    if pars.f_ignit[] == "original"
         D.ignit[] = max(586.2*(D.mrO2[])-122.102 , 0  ) 
-    elseif pars.f_ignit.v == "bookchapter"
+    elseif pars.f_ignit[] == "bookchapter"
         # TML new fn. based on data for fuel of 10% moisture content
         D.ignit[] = min(max(48.0*(D.mrO2[])-9.08 , 0  ) , 5  )
-    elseif pars.f_ignit.v == "nofbk"
+    elseif pars.f_ignit[] == "nofbk"
         D.ignit[] = 1.0
     else
-        error("Unknown f_ignit ", pars.f_ignit.v)
+        error("Unknown f_ignit ", pars.f_ignit[])
     end
 
     if isnothing(D.fireforcing)
@@ -164,7 +163,7 @@ function do_land_biota(m::PB.ReactionMethod, (D, ),  cellrange::PB.AbstractCellR
     else
         fireforcing = D.fireforcing[]
     end
-    D.firef[] = fireforcing*pars.k_fire.v/(fireforcing*pars.k_fire.v - 1 + D.ignit[])
+    D.firef[] = fireforcing*pars.k_fire[]/(fireforcing*pars.k_fire[] - 1 + D.ignit[])
 
     # Mass of terrestrial biosphere
     for i in cellrange.indices
@@ -283,21 +282,20 @@ function PB.register_methods!(rj::ReactionLandWeatheringRates)
 end
 
 
-function do_land_weathering_rates(m::PB.ReactionMethod, (D, ),  cellrange::PB.AbstractCellRange, deltat)
-    pars = m.reaction.pars
+function do_land_weathering_rates(m::PB.ReactionMethod, pars, (D, ),  cellrange::PB.AbstractCellRange, deltat)
 
     for i in cellrange.indices
         # weathering kinetics 
-        if pars.f_act_energies.v == "single"
+        if pars.f_act_energies[] == "single"
             # use same activation energy for granite and basalt  
             D.f_T_gran[i] = exp(0.09*(D.TEMP[i]-288.15))
             D.f_T_bas[i] = exp(0.09*(D.TEMP[i]-288.15))
-        elseif pars.f_act_energies.v == "split"
+        elseif pars.f_act_energies[] == "split"
             # use different activation energy for granite and basalt  
             D.f_T_gran[i] = exp(0.0724*(D.TEMP[i]-288.15)) # 50 kJ/mol 
             D.f_T_bas[i] = exp(0.0608*(D.TEMP[i]-288.15)) # 42 kJ/mol 
         else
-            error("unrecognized f_act_energies ", pars.f_act_energies.v)
+            error("unrecognized f_act_energies ", pars.f_act_energies[])
         end 
 
 
@@ -306,86 +304,86 @@ function do_land_weathering_rates(m::PB.ReactionMethod, (D, ),  cellrange::PB.Ab
 
     
         # runoff temperature dependence
-        if pars.f_runoff.v == "original"
+        if pars.f_runoff[] == "original"
             D.f_T_runoff[i] = ( max(1 + 0.038*(D.TEMP[i] - 288.15), 0)^0.65 ) # defend against low TEMP values eg transients at startup
             D.g_T_runoff[i] = max(1 + 0.087*(D.TEMP[i] - 288.15),0) # defend against low TEMP values eg transients at startup
-        elseif pars.f_runoff.v == "geoclim_2004"
-            D.f_T_runoff[i] = (D.TEMP[i] >= pars.k_runoff_freeze.v)*max(D.runoff[i], 0.0)/pars.k_runoff_mean.v
-            D.g_T_runoff[i] = (D.TEMP[i] >= pars.k_runoff_freeze.v)*sqrt(max(D.runoff[i], 0.0)/pars.k_runoff_mean.v)
-        elseif pars.f_runoff.v == "linear_runoff"
-            D.f_T_runoff[i] = (D.TEMP[i] >= pars.k_runoff_freeze.v)*max(D.runoff[i], 0.0)/pars.k_runoff_mean.v
+        elseif pars.f_runoff[] == "geoclim_2004"
+            D.f_T_runoff[i] = (D.TEMP[i] >= pars.k_runoff_freeze[])*max(D.runoff[i], 0.0)/pars.k_runoff_mean[]
+            D.g_T_runoff[i] = (D.TEMP[i] >= pars.k_runoff_freeze[])*sqrt(max(D.runoff[i], 0.0)/pars.k_runoff_mean[])
+        elseif pars.f_runoff[] == "linear_runoff"
+            D.f_T_runoff[i] = (D.TEMP[i] >= pars.k_runoff_freeze[])*max(D.runoff[i], 0.0)/pars.k_runoff_mean[]
             D.g_T_runoff[i] = D.f_T_runoff[i] 
         else
-            error("Unknown f_runoff ", pars.f_runoff.v)
+            error("Unknown f_runoff ", pars.f_runoff[])
         end 
     end
  
     # CO2 dependence 
     D.f_CO2_abiotic[] = max(D.pCO2PAL[],0)^0.5
-    if pars.f_co2fert.v == "original"
+    if pars.f_co2fert[] == "original"
          D.f_CO2_biotic[] = ( 2*max(D.pCO2PAL[],0) / (1 + max(D.pCO2PAL[],0)) )^0.4 
-    elseif pars.f_co2fert.v == "geocarb3"
+    elseif pars.f_co2fert[] == "geocarb3"
          D.f_CO2_biotic[] = ( 2*max(D.pCO2PAL[],0) / (1 + max(D.pCO2PAL[],0)) )
-    elseif pars.f_co2fert.v == "off"
+    elseif pars.f_co2fert[] == "off"
          D.f_CO2_biotic[] = 1.0
     else
-        error("Unknown f_co2fert ", pars.f_co2fert.v)
+        error("Unknown f_co2fert ", pars.f_co2fert[])
     end 
  
  
     # O2 dependence 
-    if pars.f_oxwO.v == "PowerO2"   # Copse 5_14 base with f_oxw_a = 0.5
-        D.oxw_facO[] = max(D.pO2PAL[], 0)^pars.f_oxw_a.v
+    if pars.f_oxwO[] == "PowerO2"   # Copse 5_14 base with f_oxw_a = 0.5
+        D.oxw_facO[] = max(D.pO2PAL[], 0)^pars.f_oxw_a[]
         D.oxw_facOmax[] = NaN;
-    elseif pars.f_oxwO.v == "SatO2"
-        D.oxw_facO[] = max(D.pO2PAL[], 0)/(max(D.pO2PAL[], 0) + pars.f_oxw_halfsat.v)
+    elseif pars.f_oxwO[] == "SatO2"
+        D.oxw_facO[] = max(D.pO2PAL[], 0)/(max(D.pO2PAL[], 0) + pars.f_oxw_halfsat[])
         D.oxw_facOmax[] = 1.0
-    elseif pars.f_oxwO.v == "IndepO2"
+    elseif pars.f_oxwO[] == "IndepO2"
         D.oxw_facO[] = 1
         D.oxw_facOmax[] = NaN
-    # elseif pars.f_oxwO.v == "funcO2"
+    # elseif pars.f_oxwO[] == "funcO2"
         # [oxw_O, oxwmax] = pars.f_oxwOfunc( max(pO2PAL, 0) );
         # D.oxw_facO = oxw_O/pars.f_oxwOfunc( 1.0 );
         # D.oxw_facOmax = oxwmax/pars.f_oxwOfunc( 1.0 );
     else
-        error("Unknown f_foxwO ", pars.f_oxwO.v)
+        error("Unknown f_foxwO ", pars.f_oxwO[])
     end
  
  
     # vegetation dependence
     for i in cellrange.indices
-        if pars.f_vegweath.v == "original"
+        if pars.f_vegweath[] == "original"
             D.VWmin[i] = min(D.VEG[i]*D.W[],1); 
             f_co2_gran = D.f_T_gran[i]*D.f_T_runoff[i]*(D.f_CO2_abiotic[]*(1 - D.VWmin[i]) + D.f_CO2_biotic[]*D.VWmin[i])
             f_co2_bas = D.f_T_bas[i]*D.f_T_runoff[i]*(D.f_CO2_abiotic[]*(1 - D.VWmin[i]) + D.f_CO2_biotic[]*D.VWmin[i])
             f_co2_ap = D.f_T_ap[i]*D.f_T_runoff[i]*(D.f_CO2_abiotic[]*(1 - D.VWmin[i]) + D.f_CO2_biotic[]*D.VWmin[i]) 
             g_co2 = D.g_T_runoff[i]*(D.f_CO2_abiotic[]*(1 - D.VWmin[i]) + D.f_CO2_biotic[]*D.VWmin[i])
-            W_plantenhance = (  pars.k15_plantenhance.v  + (1-pars.k15_plantenhance.v)*D.W[]*D.VEG[i]  )
+            W_plantenhance = (  pars.k15_plantenhance[]  + (1-pars.k15_plantenhance[])*D.W[]*D.VEG[i]  )
             # combining plant and other effects on rates 
             D.f_gran[i] = W_plantenhance * f_co2_gran
             D.f_bas[i] = W_plantenhance *f_co2_bas
             D.f_ap[i] = W_plantenhance * f_co2_ap
             D.f_carb[i] = W_plantenhance* g_co2
-        elseif pars.f_vegweath.v == "new"
+        elseif pars.f_vegweath[] == "new"
             D.VWmin[i] = min(D.VEG[i],1);      
-            D.f_gran[i] = D.f_T_gran[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.VEG[i]) ; 
-            D.f_bas[i] = D.f_T_bas[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.VEG[i]) ; 
-            D.f_ap[i] = D.f_T_ap[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.VEG[i]) ; 
-            D.f_carb[i] = D.g_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.VEG[i]) ; 
-        elseif pars.f_vegweath.v == "new2" 
+            D.f_gran[i] = D.f_T_gran[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.VEG[i]) ; 
+            D.f_bas[i] = D.f_T_bas[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.VEG[i]) ; 
+            D.f_ap[i] = D.f_T_ap[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.VEG[i]) ; 
+            D.f_carb[i] = D.g_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.VEG[i]) ; 
+        elseif pars.f_vegweath[] == "new2" 
             D.VWmin[i] = min(D.VEG[i]*D.W[],1); 
-            D.f_gran[i] = D.f_T_gran[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.VEG[i]*D.W[]) ; 
-            D.f_bas[i] = D.f_T_bas[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.VEG[i]*D.W[]) ; 
-            D.f_ap[i] = D.f_T_ap[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.VEG[i]*D.W[]) ; 
-            D.f_carb[i] = D.g_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.VEG[i]*D.W[]) ; 
-        elseif pars.f_vegweath.v == "newnpp"
+            D.f_gran[i] = D.f_T_gran[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.VEG[i]*D.W[]) ; 
+            D.f_bas[i] = D.f_T_bas[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.VEG[i]*D.W[]) ; 
+            D.f_ap[i] = D.f_T_ap[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.VEG[i]*D.W[]) ; 
+            D.f_carb[i] = D.g_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.VEG[i]*D.W[]) ; 
+        elseif pars.f_vegweath[] == "newnpp"
             D.VWmin[i] = min(D.V_npp[i]*D.W[],1); 
-            D.f_gran[i] = D.f_T_gran[i]*D.f_T_runoff[u]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.V_npp[i]*D.W[]) ; 
-            D.f_bas[i] = D.f_T_bas[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.V_npp[i]*D.W[]) ; 
-            D.f_ap[i] = D.f_T_ap[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.V_npp[i]*D.W[]) ; 
-            D.f_carb[i] = D.g_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance.v*D.f_CO2_abiotic[] + D.V_npp[i]*D.W[]) ; 
+            D.f_gran[i] = D.f_T_gran[i]*D.f_T_runoff[u]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.V_npp[i]*D.W[]) ; 
+            D.f_bas[i] = D.f_T_bas[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.V_npp[i]*D.W[]) ; 
+            D.f_ap[i] = D.f_T_ap[i]*D.f_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.V_npp[i]*D.W[]) ; 
+            D.f_carb[i] = D.g_T_runoff[i]*((1-D.VWmin[i])*pars.k15_plantenhance[]*D.f_CO2_abiotic[] + D.V_npp[i]*D.W[]) ; 
         else
-            error("Unknown f_vegweath ", pars.f_vegweath.v)
+            error("Unknown f_vegweath ", pars.f_vegweath[])
         end
     end
 
@@ -591,8 +589,8 @@ function PB.register_methods!(rj::ReactionLandWeatheringFluxes)
     )
 
     # isotope Types
-    CIsotopeType = rj.pars.CIsotope.v
-    SIsotopeType = rj.pars.SIsotope.v
+    CIsotopeType = rj.pars.CIsotope[]
+    SIsotopeType = rj.pars.SIsotope[]
 
     # Add flux couplers
     fluxAtoLand = PB.Fluxes.FluxContribScalar(
@@ -624,131 +622,131 @@ end
 
 function do_land_weathering_fluxes(
     m::PB.ReactionMethod,
+    pars,
     (fluxAtoLand, fluxRtoOcean, fluxLandtoSedCrust, D), 
     cellrange::PB.AbstractCellRange,
     deltat
 )
-    pars = m.reaction.pars
     (CIsotopeType, SIsotopeType) = m.p
 
     # granite weathering  
-    if pars.f_gran_link_u.v == "original"
+    if pars.f_gran_link_u[] == "original"
         granw_fac_u = D.UPLIFT[]
-    elseif pars.f_gran_link_u.v == "weak"
+    elseif pars.f_gran_link_u[] == "weak"
         granw_fac_u = (D.UPLIFT[]^0.33)
-    elseif pars.f_gran_link_u.v == "none"
+    elseif pars.f_gran_link_u[] == "none"
         granw_fac_u = 1.0
     else
-        error("unrecognized f_gran_link_u ", pars.f_gran_link_u.v)
+        error("unrecognized f_gran_link_u ", pars.f_gran_link_u[])
     end
     D.granw_relative[]  = granw_fac_u * D.PG[]*D.RHOSIL[] * D.GRAN_AREA[] * D.f_gran[]
-    D.granw[]           = D.granw_relative[] * pars.k_granw.v
+    D.granw[]           = D.granw_relative[] * pars.k_granw[]
 
     # basalt weathering
-    if pars.f_bas_link_u.v == "no"
+    if pars.f_bas_link_u[] == "no"
         basw_fac_u = 1.0
-    elseif pars.f_bas_link_u.v == "yes"
+    elseif pars.f_bas_link_u[] == "yes"
         basw_fac_u = D.UPLIFT[]
-    elseif pars.f_bas_link_u.v == "weak"
+    elseif pars.f_bas_link_u[] == "weak"
         basw_fac_u = D.UPLIFT[]^0.33
     else
-        error("unrecognized f_bas_link_u ", pars.f_bas_link_u.v)
+        error("unrecognized f_bas_link_u ", pars.f_bas_link_u[])
     end
     D.basw_relative[]   = basw_fac_u * D.PG[]*D.RHOSIL[]*D.BA_AREA[]*D.f_bas[]
-    D.basw[]            = D.basw_relative[] * pars.k_basw.v    
+    D.basw[]            = D.basw_relative[] * pars.k_basw[]    
 
     D.silw[] = D.granw[] + D.basw[]
-    k_silw = pars.k_granw.v + pars.k_basw.v
+    k_silw = pars.k_granw[] + pars.k_basw[]
     D.silw_relative[] = D.silw[] / k_silw  # define relative rate for use by other modules
 
     # apatite associated with silicate weathering
     # does it follow its own kinetics? (or that of the host rock)
-    if pars.f_p_kinetics.v == "no"
+    if pars.f_p_kinetics[] == "no"
         D.granw_ap[] = D.granw[]
         D.basw_ap[] = D.basw[]
-    elseif pars.f_p_kinetics.v == "yes"
+    elseif pars.f_p_kinetics[] == "yes"
         D.granw_ap[] = D.granw[] * (D.f_ap[] / D.f_gran[])
         D.basw_ap[] = D.basw[] * (D.f_ap[] / D.f_bas[])
     else
-        error("unrecognized f_p_kinetics ", pars.f_p_kinetics.v)
+        error("unrecognized f_p_kinetics ", pars.f_p_kinetics[])
     end
     
     # is the P content assumed to vary between granite and basalt?
-    if pars.f_p_apportion.v == "no"
+    if pars.f_p_apportion[] == "no"
         D.silw_ap[] = D.granw_ap[] + D.basw_ap[]
-    elseif pars.f_p_apportion.v == "yes"
-        D.silw_ap[] = (pars.k_P.v*D.granw_ap[] + D.basw_ap[])/(pars.k_P.v*(1-pars.k_basfrac.v)+pars.k_basfrac.v)
+    elseif pars.f_p_apportion[] == "yes"
+        D.silw_ap[] = (pars.k_P[]*D.granw_ap[] + D.basw_ap[])/(pars.k_P[]*(1-pars.k_basfrac[])+pars.k_basfrac[])
     else
-        error("unrecognized f_p_apportion ", pars.f_p_apportion.v)
+        error("unrecognized f_p_apportion ", pars.f_p_apportion[])
     end
     
-    D.phosw_s[] = D.F_EPSILON[]*pars.k10_phosw.v*pars.k_Psilw.v*(D.silw_ap[]/(k_silw + eps()))  # trap 0/0 if k_silw = 0
+    D.phosw_s[] = D.F_EPSILON[]*pars.k10_phosw[]*pars.k_Psilw[]*(D.silw_ap[]/(k_silw + eps()))  # trap 0/0 if k_silw = 0
     
 
     # carbonate weathering 
-    if pars.f_carb_link_u.v == "yes"
+    if pars.f_carb_link_u[] == "yes"
         carbw_fac_u = D.UPLIFT[]
-    elseif pars.f_carb_link_u.v == "no"
+    elseif pars.f_carb_link_u[] == "no"
         carbw_fac_u = 1.0
     else
-        error("Unknown f_carb_link_u ", pars.f_carb_link_u.v)
+        error("Unknown f_carb_link_u ", pars.f_carb_link_u[])
     end
     D.carbw_fac[] = carbw_fac_u * D.PG[]*D.RHO[]* D.CARB_AREA[] * D.f_carb[]
   
-    if pars.f_carbwC.v == "Cindep"   # Copse 5_14
+    if pars.f_carbwC[] == "Cindep"   # Copse 5_14
         carbw_fac_C = 1.0
-    elseif pars.f_carbwC.v == "Cprop"    # A generalization for varying-size C reservoir
+    elseif pars.f_carbwC[] == "Cprop"    # A generalization for varying-size C reservoir
         carbw_fac_C = D.C_norm[]
     else
-        error("Unknown f_carbw ", pars.f_carbwC.v)
+        error("Unknown f_carbw ", pars.f_carbwC[])
     end
     D.carbw_relative[] = carbw_fac_C * D.carbw_fac[]
-    D.carbw[] = D.carbw_relative[] * pars.k14_carbw.v 
+    D.carbw[] = D.carbw_relative[] * pars.k14_carbw[] 
     
     # Define a normalized weathering rate for use by tracers etc.
-    D.silwcarbw_relative[] = ( ( D.silw[] + D.carbw[] ) / ( k_silw + pars.k14_carbw.v ) )
+    D.silwcarbw_relative[] = ( ( D.silw[] + D.carbw[] ) / ( k_silw + pars.k14_carbw[] ) )
 
     # Oxidative weathering
 
     # C oxidative weathering
     # not affected by Dforce.PG in G3 paper...
-    if pars.f_oxwG.v == "Gindep"
+    if pars.f_oxwG[] == "Gindep"
         oxw_fac_G = 1.0
-    elseif pars.f_oxwG.v == "Gprop"
+    elseif pars.f_oxwG[] == "Gprop"
         oxw_fac_G = D.G_norm[]    
-    elseif pars.f_oxwG.v == "forced"
+    elseif pars.f_oxwG[] == "forced"
         oxw_fac_G = D.G_norm[]  * D.ORG_AREA[]
     else
-        error("Unknown f_oxwG ", pars.f_oxwG.v)
+        error("Unknown f_oxwG ", pars.f_oxwG[])
     end
-    D.orgcw[] = oxw_fac_G * pars.k17_oxidw.v*D.UPLIFT[] * D.oxw_facOmax[]
-    D.oxidw[] = oxw_fac_G * pars.k17_oxidw.v*D.UPLIFT[] * D.oxw_facO[]
+    D.orgcw[] = oxw_fac_G * pars.k17_oxidw[]*D.UPLIFT[] * D.oxw_facOmax[]
+    D.oxidw[] = oxw_fac_G * pars.k17_oxidw[]*D.UPLIFT[] * D.oxw_facO[]
 
     # Sulphur weathering
-    if pars.enableS.v
+    if pars.enableS[]
         # Gypsum weathering
         # not tied to Dforce.PG in G3 paper...
-        if pars.f_gypweather.v == "original" # Gypsum weathering tied to carbonate weathering
-            D.gypw[] = pars.k22_gypw.v * D.GYP_norm[]*D.carbw_fac[]
-        elseif pars.f_gypweather.v == "alternative" # independent of carbonate area
-            D.gypw[] = pars.k22_gypw.v*D.GYP_norm[]*D.UPLIFT[]*D.PG[]*D.RHO[]*D.f_carb[]
-        elseif pars.f_gypweather.v == "forced" # dependent on evaporite area
-            D.gypw[] = pars.k22_gypw.v*D.GYP_norm[]*D.EVAP_AREA[]*D.UPLIFT[]*D.PG[]*D.RHO[]*D.f_carb[]
+        if pars.f_gypweather[] == "original" # Gypsum weathering tied to carbonate weathering
+            D.gypw[] = pars.k22_gypw[] * D.GYP_norm[]*D.carbw_fac[]
+        elseif pars.f_gypweather[] == "alternative" # independent of carbonate area
+            D.gypw[] = pars.k22_gypw[]*D.GYP_norm[]*D.UPLIFT[]*D.PG[]*D.RHO[]*D.f_carb[]
+        elseif pars.f_gypweather[] == "forced" # dependent on evaporite area
+            D.gypw[] = pars.k22_gypw[]*D.GYP_norm[]*D.EVAP_AREA[]*D.UPLIFT[]*D.PG[]*D.RHO[]*D.f_carb[]
         else
-            error("unknown f_gypweather ", pars.f_gypweather.v)
+            error("unknown f_gypweather ", pars.f_gypweather[])
         end
 
         # Pyrite oxidative weathering 
         # not tied to Dforce.PG in G3 paper...
-        if pars.f_pyrweather.v == "copse_O2"
+        if pars.f_pyrweather[] == "copse_O2"
             # with same functional form as carbon
-            D.pyrw[] = pars.k21_pyrw.v*D.UPLIFT[]*D.PYR_norm[]*D.oxw_facO[]
-        elseif pars.f_pyrweather.v == "copse_noO2"    # independent of O2
-            D.pyrw[] = pars.k21_pyrw.v*D.UPLIFT[]*D.PYR_norm[]
-        elseif pars.f_pyrweather.v == "forced" # forced by exposed shale area
-            D.pyrw[] = pars.k21_pyrw.v*D.UPLIFT[]*D.SHALE_AREA[]*D.PYR_norm[]
+            D.pyrw[] = pars.k21_pyrw[]*D.UPLIFT[]*D.PYR_norm[]*D.oxw_facO[]
+        elseif pars.f_pyrweather[] == "copse_noO2"    # independent of O2
+            D.pyrw[] = pars.k21_pyrw[]*D.UPLIFT[]*D.PYR_norm[]
+        elseif pars.f_pyrweather[] == "forced" # forced by exposed shale area
+            D.pyrw[] = pars.k21_pyrw[]*D.UPLIFT[]*D.SHALE_AREA[]*D.PYR_norm[]
         else
-            error("unknown f_pyrweather ", pars.f_pyrweather.v)
+            error("unknown f_pyrweather ", pars.f_pyrweather[])
         end
         # Isotope fractionation of S
         gypw_isotope = @PB.isotope_totaldelta(SIsotopeType, D.gypw[], D.GYP_delta[])
@@ -763,10 +761,10 @@ function do_land_weathering_fluxes(
 
     # Introduction of P weathering flux from sandstones etc
     D.sedw_relative[] = D.UPLIFT[]*D.PG[]*D.RHO[]*D.VEG[]
-    D.phosw_x[] = D.F_EPSILON[]*pars.k10_phosw.v*pars.k_Psedw.v*D.sedw_relative[]
+    D.phosw_x[] = D.F_EPSILON[]*pars.k10_phosw[]*pars.k_Psedw[]*D.sedw_relative[]
     
-    D.phosw_c[] = D.F_EPSILON[]*pars.k10_phosw.v*pars.k_Pcarbw.v*(D.carbw[]/(pars.k14_carbw.v + eps()))
-    D.phosw_o[] = D.F_EPSILON[]*pars.k10_phosw.v*pars.k_Poxidw.v*(D.oxidw[]/(pars.k17_oxidw.v + eps()))  # trap 0/0 if k17_oxidw = 0
+    D.phosw_c[] = D.F_EPSILON[]*pars.k10_phosw[]*pars.k_Pcarbw[]*(D.carbw[]/(pars.k14_carbw[] + eps()))
+    D.phosw_o[] = D.F_EPSILON[]*pars.k10_phosw[]*pars.k_Poxidw[]*(D.oxidw[]/(pars.k17_oxidw[] + eps()))  # trap 0/0 if k17_oxidw = 0
     D.phosw[]   = D.phosw_s[] + D.phosw_c[] + D.phosw_o[] + D.phosw_x[]
 
 
@@ -774,29 +772,29 @@ function do_land_weathering_fluxes(
     #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
     # Land organic carbon burial
-    if     pars.f_locb.v == "original"
-        D.pland[] = pars.k11_landfrac.v*D.VEG[]*D.phosw[]
-    elseif pars.f_locb.v == "Uforced"
+    if     pars.f_locb[] == "original"
+        D.pland[] = pars.k11_landfrac[]*D.VEG[]*D.phosw[]
+    elseif pars.f_locb[] == "Uforced"
         # Uplift/erosion control of locb
-        D.pland[] = pars.k11_landfrac.v*D.UPLIFT[]*D.VEG[]*D.phosw[]
-    elseif pars.f_locb.v == "coal"
+        D.pland[] = pars.k11_landfrac[]*D.UPLIFT[]*D.VEG[]*D.phosw[]
+    elseif pars.f_locb[] == "coal"
         # Coal basin forcing of locb
-        D.pland[] = pars.k11_landfrac.v*D.VEG[]*D.phosw[]*(pars.k_aq.v+(1-pars.k_aq.v)*D.COAL[])
-    elseif pars.f_locb.v == "split"
+        D.pland[] = pars.k11_landfrac[]*D.VEG[]*D.phosw[]*(pars.k_aq[]+(1-pars.k_aq[])*D.COAL[])
+    elseif pars.f_locb[] == "split"
         # Separating aquatic and coal basin components of locb
-        D.pland[] = pars.k11_landfrac.v*D.VEG[]*D.phosw[]*(pars.k_aq.v*D.UPLIFT[]+(1-pars.k_aq.v)*D.COAL[])
-    elseif pars.f_locb.v == "Prescribed"
+        D.pland[] = pars.k11_landfrac[]*D.VEG[]*D.phosw[]*(pars.k_aq[]*D.UPLIFT[]+(1-pars.k_aq[])*D.COAL[])
+    elseif pars.f_locb[] == "Prescribed"
         # locb forced
-        D.pland[] = pars.k11_landfrac.v*D.phosw[]
+        D.pland[] = pars.k11_landfrac[]*D.phosw[]
     else
-        error("unknown f_locb ", pars.f_locb.v)
+        error("unknown f_locb ", pars.f_locb[])
     end
 
     D.psea[] = D.phosw[] - D.pland[]
 
     # Land organic carbon burial
-    if pars.f_locb.v != "Prescribed"
-        D.locb[] = D.pland[]*pars.CPland0.v*D.CPland_relative[]           
+    if pars.f_locb[] != "Prescribed"
+        D.locb[] = D.pland[]*pars.CPland0[]*D.CPland_relative[]           
     end
    
 
@@ -828,7 +826,7 @@ function do_land_weathering_fluxes(
     fluxRtoOcean.DIC[]  += DICrunoff + carbw_isotope   
 
     fluxRtoOcean.TAlk[] += 2*D.silw[] + 2*D.carbw[]
-    if pars.SRedoxAlk.v
+    if pars.SRedoxAlk[]
         fluxRtoOcean.TAlk[] += -2*D.pyrw[]
     end
 
@@ -875,18 +873,18 @@ function set_steady_state(
     @info "LandCOPSEReloaded.set_steady_state:"
 
     # oxidw
-    PB.setvalue!(landfluxes.pars.k17_oxidw, mocb + landfluxes.pars.k5_locb.v - C_degass_org)
-    @info "    set k17_oxidw=$(landfluxes.pars.k17_oxidw.v) (mol yr-1) to balance degassing and carbon burial"
+    PB.setvalue!(landfluxes.pars.k17_oxidw, mocb + landfluxes.pars.k5_locb[] - C_degass_org)
+    @info "    set k17_oxidw=$(landfluxes.pars.k17_oxidw[]) (mol yr-1) to balance degassing and carbon burial"
 
     # silicate weathering to balance degassing +/- organic C cycle
-    k_silw  = (landfluxes.pars.k17_oxidw.v - (mocb + landfluxes.pars.k5_locb.v)
+    k_silw  = (landfluxes.pars.k17_oxidw[] - (mocb + landfluxes.pars.k5_locb[])
                 + C_degass_carb + C_degass_org - sfw)
     k_silw  += S_degass # SD include sulphur degassing ("S" -> CaSO4 ?) 
     # (TODO confirm correct S to Alk factor: presumably should also be a pyr/gyp weathering-burial balance term cf Corg)
     
-    PB.setvalue!(landfluxes.pars.k_granw, k_silw*(1-landfluxes.pars.k_basfrac.v))
-    PB.setvalue!(landfluxes.pars.k_basw, k_silw*(landfluxes.pars.k_basfrac.v))
-    @info "    set k_granw=$(landfluxes.pars.k_granw.v), k_basw=$(landfluxes.pars.k_basw.v) (mol yr-1) "*
+    PB.setvalue!(landfluxes.pars.k_granw, k_silw*(1-landfluxes.pars.k_basfrac[]))
+    PB.setvalue!(landfluxes.pars.k_basw, k_silw*(landfluxes.pars.k_basfrac[]))
+    @info "    set k_granw=$(landfluxes.pars.k_granw[]), k_basw=$(landfluxes.pars.k_basw[]) (mol yr-1) "*
         " to balance degassing and organic carbon fluxes"
 
     # P weathering to balance P burial
@@ -895,14 +893,14 @@ function set_steady_state(
         # TL alternative approach to avoid redundancy and derive k11
         PB.setvalue!(
             landfluxes.pars.k10_phosw,
-            mtotpb  + (landfluxes.pars.k5_locb.v/landfluxes.pars.CPland0.v)
+            mtotpb  + (landfluxes.pars.k5_locb[]/landfluxes.pars.CPland0[])
         )        
         PB.setvalue!(
             landfluxes.pars.k11_landfrac,
-            (landfluxes.pars.k5_locb.v/landfluxes.pars.CPland0.v)/landfluxes.pars.k10_phosw.v
+            (landfluxes.pars.k5_locb[]/landfluxes.pars.CPland0[])/landfluxes.pars.k10_phosw[]
         )
-        @info "    set k10_phosw=$(landfluxes.pars.k10_phosw.v) (mol P yr-1), "*
-            "k11_landfrac=$(landfluxes.pars.k11_landfrac.v) to balance P burial"
+        @info "    set k10_phosw=$(landfluxes.pars.k10_phosw[]) (mol P yr-1), "*
+            "k11_landfrac=$(landfluxes.pars.k11_landfrac[]) to balance P burial"
     end          
 end
 

--- a/src/oceanfloor/CarbBurial.jl
+++ b/src/oceanfloor/CarbBurial.jl
@@ -39,7 +39,7 @@ end
 function PB.register_methods!(rj::ReactionCarbBurialAlk)
 
     # isotope Types
-    CIsotopeType = rj.pars.CIsotope.v
+    CIsotopeType = rj.pars.CIsotope[]
 
     # dependencies required in do_react
     vars = PB.VariableReaction[      


### PR DESCRIPTION
- Two Parameter-related updates in PALEOboxes v0.20.4 that make the syntax for
  Parameters similar to that of Variables, making code easier to read:
  - Parameters values can now be read using <par>[] instead of <par>.v
  - Optional 'pars' argument to method functions

- Robustness fixes: use PALEOboxes.model in preference to PALEOmodel.Run, in
  particular use PALEOmodel.initialize!(model) instead of PALEOmodel.initialize!(run).
  This hopefully avoids potential issues where model and run could get out of sync.