### PR TITLE
Update [compat], Julia 1.9 now required

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - '1.9' # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ Plots = "1.0"
 Roots = "1.0, 2.0"
 TestEnv = "1.0"
 XLSX = "0.7, 0.8, 0.9, 0.10"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The implementation is mathematically equivalent to the [Matlab version](https://
 
 ### Installation
 
-NB: requires Julia 1.6 or later.  To check the Julia version:
+NB: requires Julia 1.9 or later.  To check the Julia version:
 
     julia> versioninfo()
 


### PR DESCRIPTION
SciML now requires Julia 1.9, so this is the oldest version of Julia that it is feasible to support