### PR TITLE
More fixes for units, stricter tests

### DIFF
--- a/examples/COPSE/runtests.jl
+++ b/examples/COPSE/runtests.jl
@@ -28,7 +28,7 @@ skipped_testsets = [
     comparemodel = CompareOutput.copse_output_load("reloaded", "reloaded_baseline")
 
     model = copse_reloaded_reloaded_expts("reloaded", ["baseline"])
-    initial_state, modeldata = PALEOmodel.initialize!(model)
+    initial_state, modeldata = PALEOmodel.initialize!(model; check_units_opt=:error)
 
     run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
 
@@ -88,7 +88,7 @@ end
 
     model = copse_reloaded_bergman2004_expts("bergman2004", ["baseline"])
 
-    initial_state, modeldata = PALEOmodel.initialize!(model)
+    initial_state, modeldata = PALEOmodel.initialize!(model; check_units_opt=:error)
 
     run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
 
@@ -147,7 +147,7 @@ end
 
     model = copse_bergman2004_bergman2004_expts(["baseline"])
 
-    initial_state, modeldata = PALEOmodel.initialize!(model)
+    initial_state, modeldata = PALEOmodel.initialize!(model; check_units_opt=:error)
 
     run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
     

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -14,4 +14,4 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]
-PALEOmodel = "0.15.8"
+PALEOmodel = "0.15.44"

--- a/src/COPSE/ModelBergman2004.jl
+++ b/src/COPSE/ModelBergman2004.jl
@@ -116,16 +116,16 @@ function PB.register_methods!(rj::ReactionModelBergman2004)
     vars_res, vars_sms, vars_dep_res     = PB.Reservoirs.ReservoirLinksVector(
         Dict("CIsotope"=>PB.IsotopeLinear, "SIsotope"=>PB.IsotopeLinear),
         [
-            ("P",           "mol P",    "Marine phosphorus"),
-            ("N",           "mol N",    "Marine nitrogen"),
-            ("O",           "mol O2",   "Atm-ocean oxygen"),
-            ("C::CIsotope",  "mol C",    "Sedimentary carbonate"),
-            ("G::CIsotope",  "mol C",    "Sedimentary organic carbon"),
-            ("A::CIsotope",  "mol C",    "Atm-ocean inorganic carbon"),
-            ("CAL",         "mol Ca",   "Marine calcium"),
-            ("GYP::SIsotope","mol S",    "Sedimentary gypsum"),
-            ("PYR::SIsotope","mol S",    "Sedimentary pyrite"),
-            ("S::SIsotope",  "mol S",    "Marine sulphate")
+            ("P",           "mol",    "Marine phosphorus"),
+            ("N",           "mol",    "Marine nitrogen"),
+            ("O",           "mol",   "Atm-ocean oxygen"),
+            ("C::CIsotope",  "mol",    "Sedimentary carbonate"),
+            ("G::CIsotope",  "mol",    "Sedimentary organic carbon"),
+            ("A::CIsotope",  "mol",    "Atm-ocean inorganic carbon"),
+            ("CAL",         "mol",   "Marine calcium"),
+            ("GYP::SIsotope","mol",    "Sedimentary gypsum"),
+            ("PYR::SIsotope","mol",    "Sedimentary pyrite"),
+            ("S::SIsotope",  "mol",    "Marine sulphate")
         ])
  
     
@@ -134,7 +134,7 @@ function PB.register_methods!(rj::ReactionModelBergman2004)
     vars_dep_stateandeqb = PB.VarVector(PB.VarDepScalar, 
         [
             ("tforce",  "yr"   , "time for external forcings"),
-            ("SOLAR",   "W/m^2", "solar luminosity"),
+            ("SOLAR",   "W m-2", "solar luminosity"),
             ("UPLIFT",  "",      "uplift scaling"),
             ("DEGASS",  "",      "degassing scaling"),
             ("W",       "",      "plant weathering scaling"),
@@ -149,7 +149,7 @@ function PB.register_methods!(rj::ReactionModelBergman2004)
         [
             ("pO2PAL",  "",           "atmospheric oxygen relative to present-day"),
             ("pCO2PAL", "",           "atmospheric pCO2 relative to present-day"),
-            ("pCO2atm", "ppm",        "atmospheric pCO2"),
+            ("pCO2atm", "atm",        "atmospheric pCO2"),
             ("d_mccb", "per mil",     "D13C fractionation carbonate - atm-ocean inorganic carbon"),
             ("d_locb", "per mil",     "D13C fractionation land organic carbon burial - atm-ocean inorganic carbon"),
             ("d_mocb", "per mil",     "D13C fractionation marine organic carbon burial - atm-ocean inorganic carbon"),

--- a/src/landsurface/LandBergman2004.jl
+++ b/src/landsurface/LandBergman2004.jl
@@ -102,7 +102,7 @@ function PB.register_methods!(rj::ReactionLandBergman2004)
             # atm
             ("atm.pO2PAL",  "",           "atmospheric oxygen relative to present-day"),
             ("atm.pCO2PAL", "",           "atmospheric pCO2 relative to present-day"),
-            ("atm.pCO2atm", "ppm",        "atmospheric pCO2"),
+            ("atm.pCO2atm", "atm",        "atmospheric pCO2"),
             ("(atm.CO2_delta)", "per mil",  "atmospheric pCO2 delta 13C"),
             # sedcrust
             ("sedcrust.C_norm",        "",    "Sedimentary carbonate normalized to present day"),


### PR DESCRIPTION
Use PALEOmodel.initialize(model; check_units_opt=:error) in tests so that any units mismatches will result in test failures.