### PR TITLE
Use paleorun instead of run in examples

### DIFF
--- a/examples/COPSE/COPSE_bergman2004_bergman2004.jl
+++ b/examples/COPSE/COPSE_bergman2004_bergman2004.jl
@@ -23,10 +23,13 @@ comparemodel = CompareOutput.copse_output_load("bergman2004","")
 
 use_TEMP_DAE = false
 
-model = copse_bergman2004_bergman2004_expts(
-    ["baseline"],
+model = PB.create_model_from_config(
+    joinpath(@__DIR__, "COPSE_bergman2004_bergman2004_cfg.yaml"), 
+    "Bergman2004"; 
     modelpars=Dict("temp_DAE"=>use_TEMP_DAE),
 )
+
+copse_bergman2004_bergman2004_expts(model, ["baseline"])
 
 initial_state, modeldata = PALEOmodel.initialize!(model)
 
@@ -36,36 +39,36 @@ PALEOmodel.SolverFunctions.ModelODE(modeldata)(initial_deriv, initial_state , no
 println("initial_state", initial_state)
 println("initial_deriv", initial_deriv)
 
-run = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
+paleorun = PALEOmodel.Run(model=model, output = PALEOmodel.OutputWriters.OutputMemory())
 
 if use_TEMP_DAE
     println("integrate, DAE")
     # first run includes JIT time
     @time PALEOmodel.ODE.integrateDAE(
-        run, initial_state, modeldata, (-600e6, 0), 
+        paleorun, initial_state, modeldata, (-600e6, 0), 
         solvekwargs=(
             saveat=1e6, # save output every 1e6 yr see https://diffeq.sciml.ai/dev/basics/common_solver_opts/
         )
     )
     
     # sparse jacobian with IDA(linear_solver=:KLU) fails at ~-350e6 yr ?       
-    # @time PALEOmodel.ODE.integrateDAEForwardDiff(run, initial_state, modeldata, (-650e6, 0), alg=IDA(linear_solver=:KLU))
+    # @time PALEOmodel.ODE.integrateDAEForwardDiff(paleorun, initial_state, modeldata, (-650e6, 0), alg=IDA(linear_solver=:KLU))
 else
     println("integrate, ODE")
     # first run includes JIT time    
     @time PALEOmodel.ODE.integrate(
-        run, initial_state, modeldata, (-600e6, 0), 
+        paleorun, initial_state, modeldata, (-600e6, 0), 
         solvekwargs=(
             saveat=1e6, # save output every 1e6 yr see https://diffeq.sciml.ai/dev/basics/common_solver_opts/
         )
     )  
     # sparse jacobian with IDA(linear_solver=:KLU) fails at ~-350e6 yr ?       
-    # @time PALEOmodel.ODE.integrateForwardDiff(run, initial_state, modeldata, (-650e6, 0), alg=CVODE_BDF(linear_solver=:KLU))
+    # @time PALEOmodel.ODE.integrateForwardDiff(paleorun, initial_state, modeldata, (-650e6, 0), alg=CVODE_BDF(linear_solver=:KLU))
 end
 
 
 if !isnothing(comparemodel)
-    diff = CompareOutput.compare_copse_output(run.output, comparemodel)
+    diff = CompareOutput.compare_copse_output(paleorun.output, comparemodel)
     firstpoint=1
     show(sort(DataFrames.describe(diff[firstpoint:end, :], :std, :min, :max, :mean), :std), allrows=true)
 end
@@ -83,9 +86,9 @@ println()
 gr(size=(1200, 700)) # GR backend with large screen size
 pager=PALEOmodel.PlotPager(6, (legend_background_color=nothing, ))
 
-copse_bergman2004_bergman2004_plot(run.output; pager=pager)
+copse_bergman2004_bergman2004_plot(paleorun.output; pager=pager)
 if !isnothing(comparemodel)
-    copse_bergman2004_bergman2004_compare([run.output, comparemodel]; pager=pager)
+    copse_bergman2004_bergman2004_compare([paleorun.output, comparemodel]; pager=pager)
 end
 
 

--- a/examples/COPSE/COPSE_reloaded_reloaded.ipynb
+++ b/examples/COPSE/COPSE_reloaded_reloaded.ipynb
@@ -62,7 +62,12 @@
    "source": [
     "include(\"copse_reloaded_reloaded_expts.jl\")\n",
     "\n",
-    "model = copse_reloaded_reloaded_expts(\"reloaded\", [\"baseline\"])\n"
+    "model = PB.create_model_from_config(\n",
+    "    joinpath(@__DIR__, \"COPSE_reloaded_reloaded_cfg.yaml\"), \n",
+    "    \"model1\";\n",
+    ")\n",
+    "\n",
+    "copse_reloaded_reloaded_expts(model, [\"baseline\"])\n"
    ]
   },
   {

--- a/examples/COPSE/copse_bergman2004_bergman2004_expts.jl
+++ b/examples/COPSE/copse_bergman2004_bergman2004_expts.jl
@@ -1,15 +1,10 @@
 
 
 function copse_bergman2004_bergman2004_expts(
-    expts;   
-    modelpars=Dict{}(),
+    model, expts
 )
 
-    model = PB.create_model_from_config(
-        joinpath(@__DIR__, "COPSE_bergman2004_bergman2004_cfg.yaml"), 
-        "Bergman2004"; 
-        modelpars=modelpars,
-    )
+    
         
     ###############################################
     # choose an 'expt' (a delta to the base model)

--- a/examples/COPSE/copse_reloaded_bergman2004_expts.jl
+++ b/examples/COPSE/copse_reloaded_bergman2004_expts.jl
@@ -1,32 +1,8 @@
 
 
 function copse_reloaded_bergman2004_expts(
-    basemodel, expts;
-    modelpars=Dict{}(),
+    model, expts
 )
-
-
-    ####################
-    # set basemodel
-    ####################
-    if basemodel == "bergman2004"
-        # modelpars = Dict("CIsotope"=>"ScalarData", "SIsotope"=>"ScalarData", "CIsotopeReacts"=>false)
-        model = PB.create_model_from_config(
-            joinpath(@__DIR__, "COPSE_reloaded_bergman2004_cfg.yaml"), "model1", 
-            modelpars=modelpars,
-        )
-
-    elseif basemodel == "bergman2004noS"
-        modelpars=merge(modelpars, Dict("enableS"=>false, "disableS"=>true))
-        model = PB.create_model_from_config(
-            joinpath(@__DIR__, "COPSE_reloaded_bergman2004_cfg.yaml"), "model1", 
-            modelpars=modelpars
-        )
-        
-    else
-        error("unknown basemodel ", basemodel)
-    end
-
 
     ###############################################
     # choose an 'expt' (a delta to the base model)

--- a/examples/COPSE/copse_reloaded_reloaded_expts.jl
+++ b/examples/COPSE/copse_reloaded_reloaded_expts.jl
@@ -1,26 +1,7 @@
 
 function copse_reloaded_reloaded_expts(
-    basemodel, expts;
-    modelpars=Dict{}(),
+    model, expts
 )
-
-    ####################
-    # set basemodel
-    ####################
-    if basemodel == "reloaded"
-        
-        # modelpars = Dict("CIsotope"=>"ScalarData", "SIsotope"=>"ScalarData", "CIsotopeReacts"=>false)       
-        model = PB.create_model_from_config(
-            joinpath(@__DIR__, "COPSE_reloaded_reloaded_cfg.yaml"), 
-            "model1",
-            modelpars=modelpars,
-            # sort_methods_algorithm=PB.dfs_methods
-        )
-        
-    else
-        error("unknown basemodel ", basemodel)
-    end
-
 
     ###############################################
     # choose an 'expt' (a delta to the base model)

--- a/examples/COPSE/runtests.jl
+++ b/examples/COPSE/runtests.jl
@@ -27,18 +27,22 @@ skipped_testsets = [
     # load archived model output 
     comparemodel = CompareOutput.copse_output_load("reloaded", "reloaded_baseline")
 
-    model = copse_reloaded_reloaded_expts("reloaded", ["baseline"])
+    model = PB.create_model_from_config(
+        joinpath(@__DIR__, "COPSE_reloaded_reloaded_cfg.yaml"), 
+        "model1";
+    )
+    copse_reloaded_reloaded_expts(model, ["baseline"])
     initial_state, modeldata = PALEOmodel.initialize!(model; check_units_opt=:error)
 
-    run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
+    paleorun = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
 
     @time PALEOmodel.ODE.integrate(
-        run, initial_state, modeldata, (-1000e6, 0), 
+        paleorun, initial_state, modeldata, (-1000e6, 0), 
         solvekwargs=(
             reltol=1e-4,
         )
     ) 
-    # @time PALEOmodel.ODE.integrateForwardDiff(run, initial_state, modeldata, (-1000e6, 0), jac_ad_t_sparsity=0.0, solvekwargs=(reltol=1e-4,))
+    # @time PALEOmodel.ODE.integrateForwardDiff(paleorun, initial_state, modeldata, (-1000e6, 0), jac_ad_t_sparsity=0.0, solvekwargs=(reltol=1e-4,))
 
     # conservation checks
     conschecks = [  
@@ -50,7 +54,7 @@ skipped_testsets = [
     ]    
     for (varname, propertyname, rtol) in conschecks
         startval, endval = PB.get_property(
-            PB.get_data(run.output, "global."*varname), 
+            PB.get_data(paleorun.output, "global."*varname), 
             propertyname=propertyname,
         )[[1, end]]
         println("check $varname $startval $endval $rtol")
@@ -58,7 +62,7 @@ skipped_testsets = [
     end
 
     # comparison to archived output
-    diff = CompareOutput.compare_copse_output(run.output, comparemodel)
+    diff = CompareOutput.compare_copse_output(paleorun.output, comparemodel)
     firstpoint=50
     diffsummary = DataFrames.describe(diff[firstpoint:end, :], :std, :min, :max, :mean)
 
@@ -86,14 +90,17 @@ end
 
     comparemodel = CompareOutput.copse_output_load("reloaded","original_baseline")
 
-    model = copse_reloaded_bergman2004_expts("bergman2004", ["baseline"])
+    model = PB.create_model_from_config(
+        joinpath(@__DIR__, "COPSE_reloaded_bergman2004_cfg.yaml"), "model1"
+    )
+    copse_reloaded_bergman2004_expts(model, ["baseline"])
 
     initial_state, modeldata = PALEOmodel.initialize!(model; check_units_opt=:error)
 
-    run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
+    paleorun = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
 
     @time PALEOmodel.ODE.integrate(
-        run, initial_state, modeldata, (-1000e6, 0), 
+        paleorun, initial_state, modeldata, (-1000e6, 0), 
         solvekwargs=(
             reltol=1e-4,
             # saveat=1e6,
@@ -110,7 +117,7 @@ end
     ]    
     for (varname, propertyname, rtol) in conschecks
         startval, endval = PB.get_property(
-            PB.get_data(run.output, "global."*varname),
+            PB.get_data(paleorun.output, "global."*varname),
             propertyname=propertyname
         )[[1, end]]
         println("check $varname $startval $endval $rtol")
@@ -118,7 +125,7 @@ end
     end
 
     # comparison to archived output
-    diff = CompareOutput.compare_copse_output(run.output, comparemodel)
+    diff = CompareOutput.compare_copse_output(paleorun.output, comparemodel)
     firstpoint = 100
     diffsummary = DataFrames.describe(diff[firstpoint:end, :], :std, :min, :max, :mean)
 
@@ -145,14 +152,19 @@ end
 
     comparemodel = CompareOutput.copse_output_load("bergman2004","")
 
-    model = copse_bergman2004_bergman2004_expts(["baseline"])
+    model = PB.create_model_from_config(
+        joinpath(@__DIR__, "COPSE_bergman2004_bergman2004_cfg.yaml"), 
+        "Bergman2004"; 
+    )
+
+    copse_bergman2004_bergman2004_expts(model, ["baseline"])
 
     initial_state, modeldata = PALEOmodel.initialize!(model; check_units_opt=:error)
 
-    run = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
+    paleorun = PALEOmodel.Run(model=model, output=PALEOmodel.OutputWriters.OutputMemory())
     
     @time PALEOmodel.ODE.integrate(
-        run, initial_state, modeldata, (-600e6, 0),
+        paleorun, initial_state, modeldata, (-600e6, 0),
         solvekwargs=(
             saveat=1e6,
         )
@@ -168,7 +180,7 @@ end
     ]    
     for (varname, propertyname, rtol) in conschecks
         startval, endval = PB.get_property(
-            PB.get_data(run.output, "global."*varname),
+            PB.get_data(paleorun.output, "global."*varname),
             propertyname=propertyname
         )[[1, end]]
         println("check $varname $startval $endval $rtol")
@@ -176,7 +188,7 @@ end
     end
 
     # comparison to archived output
-    diff = CompareOutput.compare_copse_output(run.output, comparemodel)
+    diff = CompareOutput.compare_copse_output(paleorun.output, comparemodel)
     firstpoint = 1
     diffsummary = DataFrames.describe(diff[firstpoint:end, :], :std, :min, :max, :mean)
 


### PR DESCRIPTION
- Use 'paleorun' instead of 'run' in all examples, to avoid issues due to 'run' being a Julia functin.

- Remove a level of indirection so model is created directly using PB.create_model_from_config(...) in scripts.